### PR TITLE
tuned and mapped buttons for drive practice

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -18,7 +18,9 @@ import com.pathplanner.lib.auto.AutoBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
@@ -250,12 +252,23 @@ public class RobotContainer {
         _opButtonNine.onTrue(this._intake.buildCommand().aquire());
         _opButtonNine.onFalse(this._intake.buildCommand().stop());
 
-        _op2ButtonFour.onTrue(new GrpShootNoteInZone(_intake, _shooter, ShooterZone.Podium));
-        _op2ButtonThree.onTrue(new GrpShootNoteInZone(_intake, _shooter, ShooterZone.Subwoofer));
+        _op2ButtonTwo.onTrue(new GrpShootNoteInZone(_intake, _shooter, ShooterZone.Podium));
+        _op2ButtonOne.onTrue(new GrpShootNoteInZone(_intake, _shooter, ShooterZone.Subwoofer));
 
 
 
         _op2ButtonSix.onTrue(new GrpShootNoteInZone(_intake, _shooter, _shooter.getCurrentZone()));
+        _op2ButtonSix.onTrue(new Command() {
+
+            @Override
+            public void initialize(){
+                _shooter.setFlywheelSpeed(0.0);
+            }
+
+            @Override
+            public boolean isFinished(){return true;}
+        }
+        );
 
         //_opButtonFive.onTrue(new GrpShootNoteInZone(_intake, _shooter, _drive));
 

--- a/src/main/java/frc/robot/subsystems/intake/IntakeConstants.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeConstants.java
@@ -31,7 +31,7 @@ public class IntakeConstants {
      * 
      **********************/
     public static final double POSITION_SOURCE_PICKUP = 50;
-    public static final double POSITION_GROUND_PICKUP = 175;
+    public static final double POSITION_GROUND_PICKUP = 172;
     public static final double POSITION_STOWED = 5;
     public static final double POSITION_AMP_SCORE = 60;
     public static final double POSITION_SPEAKER_SCORE = 115;

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterConstants.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterConstants.java
@@ -21,13 +21,13 @@ public abstract class ShooterConstants {
     public static final double ZONE_PODIUM_FLYWHEEL_SPEED = 1750;
     public static final double ZONE_PODIUM_LOW_BOUND = 4;
     public static final double ZONE_PODIUM_UPPER_BOUND = 2.5;
-    public static final double ZONE_PODIUM_SHOOTER_ANGLE = 30;
+    public static final double ZONE_PODIUM_SHOOTER_ANGLE = 22;
 
     // subwoofer
-    public static final double ZONE_SUBWOOFER_FLYWHEEL_SPEED = 1000;
+    public static final double ZONE_SUBWOOFER_FLYWHEEL_SPEED = 1300;
     public static final double ZONE_SUBWOOFER_LOW_BOUND = 0.0;
     public static final double ZONE_SUBWOOFER_UPPER_BOUND = 2.5;
-    public static final double ZONE_SUBWOOFER_SHOOTER_ANGLE = 41;
+    public static final double ZONE_SUBWOOFER_SHOOTER_ANGLE = 40;
 
     // unkown
     public static final double ZONE_UNKOWN_FLYWHEEL_SPEED = 200;
@@ -63,6 +63,6 @@ public abstract class ShooterConstants {
      * SHOOTER SOFTWARE CONSTANTS
      * 
      *****************/
-    public static final double FLYWHEEL_SPEED_DEADBAND = 250;
+    public static final double FLYWHEEL_SPEED_DEADBAND = 50;
 
 }


### PR DESCRIPTION
This is the code and constants we ran for drive practice at the end of saturday on week 1. this code is stable to run but not 100% bug free. its mostly just edge cases. The biggest one was sometimes the robot would think it picked up a note and the has_note boolean would be true. but then we couldn't pick up a note because it thought we already had one. so we had to hit spit, which cleared the boolean.

note: the PIDs in auto for the intake are NOT working right now. its an issue with the run PID command for the intake and the way its called. 